### PR TITLE
Fething post (in get al, feed distance, & feed timestamp) now also display username & profile picture of the creator

### DIFF
--- a/src/main/java/com/safetypin/post/controller/PostController.java
+++ b/src/main/java/com/safetypin/post/controller/PostController.java
@@ -102,8 +102,13 @@ public class PostController {
             Pageable pageable = PageRequest.of(page, size);
             Page<Post> postsPage = postService.findAllPaginated(pageable);
 
+            // fetch profiles
+            List<PostedByData> profileList = null;
+            profileList = postService.fetchProfiles();
+
+            List<PostedByData> finalProfileList = profileList;
             List<PostData> formattedPosts = postsPage.getContent().stream()
-                    .map(post -> PostData.fromPostAndUserId(post, userId))
+                    .map(post -> PostData.fromPostAndUserId(post, userId, finalProfileList))
                     .toList();
 
             Map<String, Object> paginationData = createPaginationData(
@@ -258,7 +263,10 @@ public class PostController {
 
             Post post = postService.findById(id);
 
-            PostData postData = PostData.fromPostAndUserId(post, userId);
+            // fetch profiles
+            List<PostedByData> profileList = postService.fetchProfiles();
+
+            PostData postData = PostData.fromPostAndUserId(post, userId, profileList);
             return createSuccessResponse(postData);
         }, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/com/safetypin/post/dto/AuthResponse.java
+++ b/src/main/java/com/safetypin/post/dto/AuthResponse.java
@@ -1,0 +1,16 @@
+package com.safetypin.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@AllArgsConstructor
+public class AuthResponse {
+    private boolean success;
+    private String message;
+    private Object data;
+}

--- a/src/main/java/com/safetypin/post/dto/PostData.java
+++ b/src/main/java/com/safetypin/post/dto/PostData.java
@@ -6,11 +6,13 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Data
 @Builder
 public class PostData {
+
     private UUID id; // Add id field
     private String title;
     private String caption;
@@ -21,7 +23,7 @@ public class PostData {
     private Long upvoteCount;
     private Long downvoteCount;
     private VoteType currentVote;
-    private UUID postedBy;
+    private PostedByData postedBy;
 
     /**
      * Creates a PostData object from a Post entity
@@ -30,7 +32,33 @@ public class PostData {
      * @param userId The ID of the user viewing the post
      * @return A PostData instance
      */
-    public static PostData fromPostAndUserId(Post post, UUID userId) {
+    public static PostData fromPostAndUserId(Post post, UUID userId, List<PostedByData> profiles) {
+
+
+        PostedByData postedByData = new PostedByData(post.getPostedBy(), null, null);
+        if (profiles == null || profiles.isEmpty()) {
+            // can't fetch postedBy
+        } else {
+            // iterate profiles
+            PostedByData profileResponse = null;
+            for (PostedByData profile : profiles) {
+                if (profile.getId().equals(post.getPostedBy())) {
+                    profileResponse = profile;
+                    break;
+                }
+            }
+            if (profileResponse == null) {
+                // can't fetch postedBy
+            } else {
+                postedByData = PostedByData.builder()
+                        .id(userId)
+                        .profilePicture(profileResponse.getProfilePicture())
+                        .name(profileResponse.getName())
+                        .build();
+            }
+
+        }
+
         return PostData.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -42,7 +70,7 @@ public class PostData {
                 .upvoteCount(post.getUpvoteCount())
                 .downvoteCount(post.getDownvoteCount())
                 .currentVote(post.currentVote(userId))
-                .postedBy(post.getPostedBy())
+                .postedBy(postedByData)
                 .build();
     }
 }

--- a/src/main/java/com/safetypin/post/dto/PostedByData.java
+++ b/src/main/java/com/safetypin/post/dto/PostedByData.java
@@ -1,0 +1,15 @@
+package com.safetypin.post.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@Builder
+public class PostedByData {
+    private UUID id;
+    private String name;
+    private String profilePicture;
+
+}

--- a/src/main/java/com/safetypin/post/service/PostService.java
+++ b/src/main/java/com/safetypin/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.safetypin.post.service;
 
 import com.safetypin.post.dto.FeedQueryDTO;
 import com.safetypin.post.dto.PostCreateRequest;
+import com.safetypin.post.dto.PostedByData;
 import com.safetypin.post.model.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,4 +30,6 @@ public interface PostService {
 
     // Method using strategy pattern for feed algorithms
     Page<Map<String, Object>> getFeed(FeedQueryDTO queryDTO, String feedType);
+
+    List<PostedByData> fetchProfiles();
 }

--- a/src/main/java/com/safetypin/post/service/strategy/AbstractFeedStrategy.java
+++ b/src/main/java/com/safetypin/post/service/strategy/AbstractFeedStrategy.java
@@ -1,6 +1,7 @@
 package com.safetypin.post.service.strategy;
 
 import com.safetypin.post.model.Post;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+
+@NoArgsConstructor
 public abstract class AbstractFeedStrategy implements FeedStrategy {
 
     // Common utility methods

--- a/src/main/java/com/safetypin/post/service/strategy/DistanceFeedStrategy.java
+++ b/src/main/java/com/safetypin/post/service/strategy/DistanceFeedStrategy.java
@@ -2,6 +2,7 @@ package com.safetypin.post.service.strategy;
 
 import com.safetypin.post.dto.FeedQueryDTO;
 import com.safetypin.post.dto.PostData;
+import com.safetypin.post.dto.PostedByData;
 import com.safetypin.post.model.Post;
 import com.safetypin.post.utils.DistanceCalculator;
 import org.springframework.data.domain.Page;
@@ -16,8 +17,9 @@ import java.util.Map;
 public class DistanceFeedStrategy extends AbstractFeedStrategy {
     private static final String DISTANCE_KEY = "distance";
 
+
     @Override
-    public Page<Map<String, Object>> processFeed(List<Post> posts, FeedQueryDTO queryDTO) {
+    public Page<Map<String, Object>> processFeed(List<Post> posts, FeedQueryDTO queryDTO, List<PostedByData> profileList) {
         if (queryDTO.getUserLat() == null || queryDTO.getUserLon() == null) {
             throw new IllegalArgumentException("Latitude and longitude are required for distance feed");
         }
@@ -28,7 +30,8 @@ public class DistanceFeedStrategy extends AbstractFeedStrategy {
                 .filter(post -> matchesDateRange(post, queryDTO.getDateFrom(), queryDTO.getDateTo()))
                 .map(post -> {
                     Map<String, Object> result = new HashMap<>();
-                    PostData postData = PostData.fromPostAndUserId(post, queryDTO.getUserId());
+
+                    PostData postData = PostData.fromPostAndUserId(post, queryDTO.getUserId(), profileList);
                     result.put("post", postData);
 
                     // Calculate distance from user

--- a/src/main/java/com/safetypin/post/service/strategy/FeedStrategy.java
+++ b/src/main/java/com/safetypin/post/service/strategy/FeedStrategy.java
@@ -1,6 +1,7 @@
 package com.safetypin.post.service.strategy;
 
 import com.safetypin.post.dto.FeedQueryDTO;
+import com.safetypin.post.dto.PostedByData;
 import com.safetypin.post.model.Post;
 import org.springframework.data.domain.Page;
 
@@ -8,5 +9,5 @@ import java.util.List;
 import java.util.Map;
 
 public interface FeedStrategy {
-    Page<Map<String, Object>> processFeed(List<Post> posts, FeedQueryDTO queryDTO);
+    Page<Map<String, Object>> processFeed(List<Post> posts, FeedQueryDTO queryDTO, List<PostedByData> profileList);
 }

--- a/src/main/java/com/safetypin/post/service/strategy/TimestampFeedStrategy.java
+++ b/src/main/java/com/safetypin/post/service/strategy/TimestampFeedStrategy.java
@@ -2,6 +2,7 @@ package com.safetypin.post.service.strategy;
 
 import com.safetypin.post.dto.FeedQueryDTO;
 import com.safetypin.post.dto.PostData;
+import com.safetypin.post.dto.PostedByData;
 import com.safetypin.post.model.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
@@ -14,15 +15,16 @@ import java.util.Map;
 @Component
 public class TimestampFeedStrategy extends AbstractFeedStrategy {
 
+
     @Override
-    public Page<Map<String, Object>> processFeed(List<Post> posts, FeedQueryDTO queryDTO) {
+    public Page<Map<String, Object>> processFeed(List<Post> posts, FeedQueryDTO queryDTO, List<PostedByData> profileList) {
         List<Map<String, Object>> filteredPosts = posts.stream()
                 .filter(post -> matchesCategories(post, queryDTO.getCategories()))
                 .filter(post -> matchesKeyword(post, queryDTO.getKeyword()))
                 .filter(post -> matchesDateRange(post, queryDTO.getDateFrom(), queryDTO.getDateTo()))
                 .map(post -> {
                     Map<String, Object> result = new HashMap<>();
-                    PostData postData = PostData.fromPostAndUserId(post, queryDTO.getUserId());
+                    PostData postData = PostData.fromPostAndUserId(post, queryDTO.getUserId(), profileList);
                     result.put("post", postData);
                     return result;
                 })

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+server.port=8081

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,6 @@ aws.s3.bucket-name=safetypin
 aws.s3.region=ap-southeast-2
 # JWT
 jwt.secret=${JWT_SECRET_KEY:wjii9rguinj3k4kiwedsiuonj32jiiew99ij324rjifsnf}
-
 management.endpoints.web.exposure.include=health,prometheus
 management.prometheus.metrics.export.enabled=true
+be-auth=https://safetypin.ppl.cs.ui.ac.id

--- a/src/test/java/com/safetypin/post/controller/PostControllerTest.java
+++ b/src/test/java/com/safetypin/post/controller/PostControllerTest.java
@@ -26,10 +26,14 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class PostControllerTest {
@@ -151,7 +155,8 @@ class PostControllerTest {
     @Test
     void getPostsFeedByDistance_withFilters() {
         // Arrange
-        PostData postData = PostData.fromPostAndUserId(testPost, testUserId);
+        List<PostedByData> profileList = postService.fetchProfiles();
+        PostData postData = PostData.fromPostAndUserId(testPost, testUserId, profileList);
         Map<String, Object> postMap = Map.of("post", postData, "distance", 2.5);
         List<Map<String, Object>> posts = Collections.singletonList(postMap);
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
@@ -214,7 +219,8 @@ class PostControllerTest {
     @Test
     void getPostsFeedByDistance_withNullDates() {
         // Arrange
-        PostData postData = PostData.fromPostAndUserId(testPost, testUserId);
+        List<PostedByData> profileList = postService.fetchProfiles();
+        PostData postData = PostData.fromPostAndUserId(testPost, testUserId, profileList);
         Map<String, Object> postMap = Map.of("post", postData, "distance", 2.5);
         List<Map<String, Object>> posts = Collections.singletonList(postMap);
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
@@ -249,7 +255,8 @@ class PostControllerTest {
     @Test
     void getPostsFeedByTimestamp_success() {
         // Arrange
-        PostData postData = PostData.fromPostAndUserId(testPost, testUserId);
+        List<PostedByData> profileList = postService.fetchProfiles();
+        PostData postData = PostData.fromPostAndUserId(testPost, testUserId, profileList);
         Map<String, Object> postMap = Map.of("post", postData);
         List<Map<String, Object>> posts = Collections.singletonList(postMap);
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
@@ -286,7 +293,8 @@ class PostControllerTest {
     @Test
     void getPostsFeedByTimestamp_withNullDates() {
         // Arrange
-        PostData postData = PostData.fromPostAndUserId(testPost, testUserId);
+        List<PostedByData> profileList = postService.fetchProfiles();
+        PostData postData = PostData.fromPostAndUserId(testPost, testUserId, profileList);
         Map<String, Object> postMap = Map.of("post", postData);
         List<Map<String, Object>> posts = Collections.singletonList(postMap);
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
@@ -323,7 +331,8 @@ class PostControllerTest {
     @Test
     void getPostBySpecificUser_success() {
         // Arrange
-        PostData postData = PostData.fromPostAndUserId(testPost, testUserId);
+        List<PostedByData> profileList = postService.fetchProfiles();
+        PostData postData = PostData.fromPostAndUserId(testPost, testUserId, profileList);
         Map<String, Object> postMap = Map.of("post", postData);
         List<Map<String, Object>> posts = List.of(postMap);
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());

--- a/src/test/java/com/safetypin/post/dto/PostDataTest.java
+++ b/src/test/java/com/safetypin/post/dto/PostDataTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 class PostDataTest {
 
+
     @Test
     void testPostDataBuilder() {
         // Given
@@ -25,7 +26,14 @@ class PostDataTest {
         Long upvoteCount = 10L;
         Long downvoteCount = 5L;
         VoteType currentVote = VoteType.UPVOTE;
-        UUID postedBy = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        String name = "Hoho";
+        String profilePicture = "www.google.com";
+        PostedByData postedBy = PostedByData.builder()
+                .id(userId)
+                .name(name)
+                .profilePicture(profilePicture)
+                .build();
 
         // When
         PostData postData = PostData.builder()
@@ -51,7 +59,7 @@ class PostDataTest {
         assertEquals(upvoteCount, postData.getUpvoteCount());
         assertEquals(downvoteCount, postData.getDownvoteCount());
         assertEquals(currentVote, postData.getCurrentVote());
-        assertEquals(postedBy, postData.getPostedBy());
+        assertEquals(postedBy.getId(), postData.getPostedBy().getId());
     }
 
     @Test
@@ -83,7 +91,7 @@ class PostDataTest {
         when(mockPost.getPostedBy()).thenReturn(postedById);
 
         // When
-        PostData result = PostData.fromPostAndUserId(mockPost, userId);
+        PostData result = PostData.fromPostAndUserId(mockPost, userId, null);
 
         // Then
         assertNotNull(result);
@@ -96,7 +104,7 @@ class PostDataTest {
         assertEquals(upvoteCount, result.getUpvoteCount());
         assertEquals(downvoteCount, result.getDownvoteCount());
         assertEquals(currentVote, result.getCurrentVote());
-        assertEquals(postedById, result.getPostedBy());
+        assertEquals(postedById, result.getPostedBy().getId());
 
         // Verify that currentVote was called with the correct userId
         Mockito.verify(mockPost).currentVote(userId);
@@ -120,7 +128,7 @@ class PostDataTest {
         when(mockPost.getPostedBy()).thenReturn(null);
 
         // When
-        PostData result = PostData.fromPostAndUserId(mockPost, userId);
+        PostData result = PostData.fromPostAndUserId(mockPost, userId, null);
 
         // Then
         assertNotNull(result);
@@ -133,14 +141,21 @@ class PostDataTest {
         assertNull(result.getUpvoteCount());
         assertNull(result.getDownvoteCount());
         assertNull(result.getCurrentVote());
-        assertNull(result.getPostedBy());
+        assertNull(result.getPostedBy().getId());
     }
 
     @Test
     void testEqualsAndHashCode() {
         // Given
         LocalDateTime now = LocalDateTime.now();
-        UUID postedBy = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        String name = "Hoho";
+        String profilePicture = "www.google.com";
+        PostedByData postedBy = PostedByData.builder()
+                .id(userId)
+                .name(name)
+                .profilePicture(profilePicture)
+                .build();
 
         PostData postData1 = PostData.builder()
                 .title("Title")
@@ -193,7 +208,14 @@ class PostDataTest {
     void testToString() {
         // Given
         LocalDateTime now = LocalDateTime.now();
-        UUID postedBy = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        String name = "Hoho";
+        String profilePicture = "www.google.com";
+        PostedByData postedBy = PostedByData.builder()
+                .id(userId)
+                .name(name)
+                .profilePicture(profilePicture)
+                .build();
 
         PostData postData = PostData.builder()
                 .title("Title")
@@ -223,4 +245,5 @@ class PostDataTest {
         assertTrue(toStringResult.contains("UPVOTE"));
         assertTrue(toStringResult.contains(postedBy.toString()));
     }
+
 }

--- a/src/test/java/com/safetypin/post/service/PostServiceTest.java
+++ b/src/test/java/com/safetypin/post/service/PostServiceTest.java
@@ -3,6 +3,7 @@ package com.safetypin.post.service;
 import com.safetypin.post.dto.FeedQueryDTO;
 import com.safetypin.post.dto.PostCreateRequest;
 import com.safetypin.post.dto.PostData;
+import com.safetypin.post.dto.PostedByData;
 import com.safetypin.post.exception.*;
 import com.safetypin.post.model.Category;
 import com.safetypin.post.model.Post;
@@ -28,6 +29,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Stream;
@@ -56,9 +58,6 @@ class PostServiceTest {
     private UUID userId1, userId2;
     private Post postWithoutLocation;
     private Category safetyCategory;
-    private final LocalDateTime now = LocalDateTime.now(),
-            yesterday = now.minusDays(1),
-            tomorrow = now.plusDays(1);
 
     /**
      * Arguments provider for title and content validation tests
@@ -211,7 +210,9 @@ class PostServiceTest {
 
         // Then
         assertEquals(allPosts, result);
-    }
+    }    private final LocalDateTime now = LocalDateTime.now(),
+            yesterday = now.minusDays(1),
+            tomorrow = now.plusDays(1);
 
     @Test
     void testCreatePost_NullLongitude() {
@@ -617,7 +618,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -628,7 +629,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -664,7 +665,7 @@ class PostServiceTest {
         Page<Map<String, Object>> expectedResult = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(expectedResult);
 
         // Call the method we're testing
@@ -675,7 +676,7 @@ class PostServiceTest {
         assertTrue(result.getContent().isEmpty());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -725,7 +726,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -736,7 +737,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -782,7 +783,7 @@ class PostServiceTest {
         Page<Map<String, Object>> expectedResult = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(expectedResult);
 
         // Call the method we're testing
@@ -793,7 +794,7 @@ class PostServiceTest {
         assertTrue(result.getContent().isEmpty());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -843,7 +844,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -854,7 +855,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -900,8 +901,9 @@ class PostServiceTest {
         Page<Map<String, Object>> expectedResult = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(expectedResult);
+        when(postService.fetchProfiles()).thenReturn(null);
 
         // Call the method we're testing
         Page<Map<String, Object>> result = postService.getFeed(expectedDto, "distance");
@@ -911,7 +913,7 @@ class PostServiceTest {
         assertTrue(result.getContent().isEmpty());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -971,7 +973,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -982,7 +984,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -1057,7 +1059,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1068,7 +1070,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(postRepository).findAll();
         // Verify category repository is not called since we're not validating
         // categories
@@ -1115,7 +1117,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1126,7 +1128,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -1158,7 +1160,7 @@ class PostServiceTest {
         Page<Map<String, Object>> expectedResult = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(expectedResult);
 
         // Call the method we're testing
@@ -1169,7 +1171,7 @@ class PostServiceTest {
         assertTrue(result.getContent().isEmpty());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -1204,7 +1206,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1215,7 +1217,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(postRepository).findAll();
     }
 
@@ -1261,7 +1263,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1272,7 +1274,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(postRepository).findAll();
     }
 
@@ -1338,7 +1340,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1349,7 +1351,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(postRepository).findAll();
         // Verify category repository is not called since we're not validating
         // categories
@@ -1403,7 +1405,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1414,7 +1416,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(postRepository).findAll();
     }
 
@@ -1468,7 +1470,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1479,7 +1481,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(postRepository).findAll();
     }
 
@@ -1514,7 +1516,7 @@ class PostServiceTest {
         Page<Map<String, Object>> expectedResult = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
         // Setup the strategy mock to return our expected result
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(expectedResult);
 
         // Call the method we're testing
@@ -1525,7 +1527,7 @@ class PostServiceTest {
         assertTrue(result.getContent().isEmpty());
 
         // Verify the correct strategy was called with expected parameters
-        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(distanceFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(postRepository).findAll();
     }
 
@@ -1580,7 +1582,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1591,7 +1593,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
     }
@@ -1705,7 +1707,7 @@ class PostServiceTest {
         Page<Map<String, Object>> postsPage = new PageImpl<>(posts, pageable, posts.size());
 
         // Setup the strategy mock to return our expected result
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(postsPage);
 
         // Call the method we're testing
@@ -1716,7 +1718,7 @@ class PostServiceTest {
         assertEquals(1, result.getContent().size());
 
         // Verify the correct strategy was called with expected parameters
-        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto));
+        verify(timestampFeedStrategy).processFeed(anyList(), eq(expectedDto), any());
         verify(postRepository).findAll();
     }
 
@@ -1753,7 +1755,7 @@ class PostServiceTest {
                 pageable, 1);
 
         // Setup the strategy mock
-        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(distanceFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(expectedResult);
 
         // When
@@ -1766,7 +1768,7 @@ class PostServiceTest {
         ArgumentCaptor<List<Post>> postsCaptor = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<FeedQueryDTO> dtoCaptor = ArgumentCaptor.forClass(FeedQueryDTO.class);
 
-        verify(distanceFeedStrategy).processFeed(postsCaptor.capture(), dtoCaptor.capture());
+        verify(distanceFeedStrategy).processFeed(postsCaptor.capture(), dtoCaptor.capture(), null);
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
 
@@ -1803,7 +1805,7 @@ class PostServiceTest {
                 pageable, 1);
 
         // Setup the strategy mock
-        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class)))
+        when(timestampFeedStrategy.processFeed(anyList(), any(FeedQueryDTO.class), any()))
                 .thenReturn(expectedResult);
 
         // When
@@ -1816,7 +1818,7 @@ class PostServiceTest {
         ArgumentCaptor<List<Post>> postsCaptor = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<FeedQueryDTO> dtoCaptor = ArgumentCaptor.forClass(FeedQueryDTO.class);
 
-        verify(timestampFeedStrategy).processFeed(postsCaptor.capture(), dtoCaptor.capture());
+        verify(timestampFeedStrategy).processFeed(postsCaptor.capture(), dtoCaptor.capture(), null);
         verify(categoryRepository).findByName("Safety");
         verify(postRepository).findAll();
 
@@ -1878,7 +1880,6 @@ class PostServiceTest {
         verifyNoInteractions(timestampFeedStrategy);
         verifyNoInteractions(distanceFeedStrategy);
     }
-
 
     @Test
     void testFindPostsByUser_Success() {
@@ -1959,11 +1960,11 @@ class PostServiceTest {
         // Create 5 posts
         List<Post> userPosts = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
-                Post post = new Post();
-                post.setTitle("Post " + i);
-                post.setPostedBy(userId);
-                post.setCreatedAt(now.minusDays(i));
-                userPosts.add(post);
+            Post post = new Post();
+            post.setTitle("Post " + i);
+            post.setPostedBy(userId);
+            post.setCreatedAt(now.minusDays(i));
+            userPosts.add(post);
         }
 
         // Setup expected pages
@@ -2014,4 +2015,14 @@ class PostServiceTest {
         verify(postRepository, times(3))
                 .findByPostedByOrderByCreatedAtDesc(eq(userId), any(Pageable.class));
     }
+
+    @Test
+    void testFetchProfiles() throws IOException {
+        List<PostedByData> profileList = postService.fetchProfiles();
+        assertNotNull(profileList);
+    }
+
+
+
+
 }

--- a/src/test/java/com/safetypin/post/service/strategy/AbstractFeedStrategyTest.java
+++ b/src/test/java/com/safetypin/post/service/strategy/AbstractFeedStrategyTest.java
@@ -1,6 +1,7 @@
 package com.safetypin.post.service.strategy;
 
 import com.safetypin.post.dto.FeedQueryDTO;
+import com.safetypin.post.dto.PostedByData;
 import com.safetypin.post.model.Post;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -281,7 +282,7 @@ class AbstractFeedStrategyTest {
     // Concrete implementation for testing
     private static class TestFeedStrategy extends AbstractFeedStrategy {
         @Override
-        public Page<Map<String, Object>> processFeed(List<Post> posts, FeedQueryDTO queryDTO) {
+        public Page<Map<String, Object>> processFeed(List<Post> posts, FeedQueryDTO queryDTO, List<PostedByData> profileList) {
             // Simple implementation for testing
             List<Map<String, Object>> results = new ArrayList<>();
             return paginateResults(results, queryDTO.getPageable());

--- a/src/test/java/com/safetypin/post/service/strategy/DistanceFeedStrategyTest.java
+++ b/src/test/java/com/safetypin/post/service/strategy/DistanceFeedStrategyTest.java
@@ -79,7 +79,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act & Assert
-        assertThrows(IllegalArgumentException.class, () -> strategy.processFeed(posts, queryDTO));
+        assertThrows(IllegalArgumentException.class, () -> strategy.processFeed(posts, queryDTO, null));
     }
 
     @Test
@@ -92,7 +92,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act & Assert
-        assertThrows(IllegalArgumentException.class, () -> strategy.processFeed(posts, queryDTO));
+        assertThrows(IllegalArgumentException.class, () -> strategy.processFeed(posts, queryDTO, null));
     }
 
     @Test
@@ -105,7 +105,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act & Assert
-        assertThrows(IllegalArgumentException.class, () -> strategy.processFeed(posts, queryDTO));
+        assertThrows(IllegalArgumentException.class, () -> strategy.processFeed(posts, queryDTO, null));
     }
 
     @Test
@@ -119,7 +119,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(Collections.emptyList(), queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(Collections.emptyList(), queryDTO, null);
 
         // Assert
         assertTrue(result.isEmpty());
@@ -137,7 +137,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(3, result.getTotalElements());
@@ -169,7 +169,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(1, result.getTotalElements());
@@ -188,7 +188,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(1, result.getTotalElements());
@@ -207,7 +207,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(2, result.getTotalElements());
@@ -225,7 +225,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(2, result.getTotalElements());
@@ -245,7 +245,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(1, result.getTotalElements());
@@ -263,7 +263,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(2, result.getContent().size());
@@ -284,7 +284,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(1, result.getContent().size());
@@ -321,7 +321,7 @@ class DistanceFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(testPosts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(testPosts, queryDTO, null);
 
         // Assert
         assertEquals(3, result.getTotalElements());

--- a/src/test/java/com/safetypin/post/service/strategy/TimestampFeedStrategyTest.java
+++ b/src/test/java/com/safetypin/post/service/strategy/TimestampFeedStrategyTest.java
@@ -77,7 +77,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(Collections.emptyList(), queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(Collections.emptyList(), queryDTO, null);
 
         // Assert
         assertTrue(result.isEmpty());
@@ -93,7 +93,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(3, result.getTotalElements());
@@ -115,7 +115,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(1, result.getTotalElements());
@@ -132,7 +132,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(1, result.getTotalElements());
@@ -149,7 +149,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(2, result.getTotalElements());
@@ -165,7 +165,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(2, result.getTotalElements());
@@ -183,7 +183,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(2, result.getTotalElements());
@@ -198,7 +198,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(2, result.getContent().size());
@@ -217,7 +217,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(1, result.getContent().size());
@@ -236,7 +236,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertTrue(result.isEmpty());
@@ -268,7 +268,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(testPosts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(testPosts, queryDTO, null);
 
         // Assert
         assertEquals(0, result.getTotalElements());
@@ -285,7 +285,7 @@ class TimestampFeedStrategyTest {
                 .build();
 
         // Act
-        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO);
+        Page<Map<String, Object>> result = strategy.processFeed(posts, queryDTO, null);
 
         // Assert
         assertEquals(2, result.getTotalElements());


### PR DESCRIPTION
This pull request (PR) introduces significant changes to the post service, primarily focused on enriching post data with user profile information (username and profile picture). Here's a detailed review:

### Summary of Changes:

Feature Implementation:
- Fetches user profile data from an external authentication service (be-auth).
- Includes username and profile picture in PostData DTO.
- Modifies PostController and PostService to incorporate profile data in post retrieval and feed generation.
- Updates DistanceFeedStrategy and TimestampFeedStrategy to include profile information.

Code Improvements:
- Creates a new PostedByData DTO to encapsulate user profile details.
- Adds AuthResponse DTO to handle responses from the auth service.
- Improves PostData to include PostedByData.

Configuration:
- Adds be-auth configuration to application.properties.
- Adds server.port to application-dev.properties.

Tests:
- Updates existing tests to accommodate the new profile data.
- Creates new tests to make sure the new functionality is working as intended.

This PR effectively implements the requested feature, however some of the old tests seem to be failing because of the significant code change. Any help or feedback are welcome.