### PR TITLE
Implement limit post per day

### DIFF
--- a/src/main/java/com/safetypin/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/safetypin/post/dto/PostCreateRequest.java
@@ -28,7 +28,7 @@ public class PostCreateRequest {
     @JsonProperty(value = "Category", required = true)
     private String category;
 
-    private UUID postedBy; // DEPRECIATED?? karena postedBy diambil dari token JWT
+    private UUID postedBy; // The HTTP request doesn't have to fill this field (it will be replaced with userId from jwtToken anyway)
     private String imageUrl;
     private String address;
 }

--- a/src/main/java/com/safetypin/post/dto/UserDetails.java
+++ b/src/main/java/com/safetypin/post/dto/UserDetails.java
@@ -1,14 +1,13 @@
 package com.safetypin.post.dto;
 
-import java.util.UUID;
-
 import com.safetypin.post.model.Role;
-
 import io.jsonwebtoken.Claims;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+
+import java.util.UUID;
 
 @Data
 @AllArgsConstructor
@@ -18,6 +17,8 @@ public class UserDetails {
     public static final int PREMIUM_USER_TITLE_LIMIT = 140;
     public static final int REGISTERED_USER_CAPTION_LIMIT = 200;
     public static final int PREMIUM_USER_CAPTION_LIMIT = 800;
+    public static final int REGISTERED_USER_POST_PER_DAY_LIMIT = 3;
+    public static final int PREMIUM_USER_POST_PER_DAY_LIMIT = 10;
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -27,7 +28,7 @@ public class UserDetails {
 
     public static UserDetails fromClaims(Claims claims) {
         return new UserDetails(
-                claims.get("role", Role.class),
+                Role.valueOf(claims.get("role", String.class)),
                 claims.get("isVerified", Boolean.class),
                 UUID.fromString(claims.get("userId", String.class)),
                 claims.get("name", String.class));
@@ -43,5 +44,9 @@ public class UserDetails {
 
     public int getCaptionCharacterLimit() {
         return isPremiumUser() ? PREMIUM_USER_CAPTION_LIMIT : REGISTERED_USER_CAPTION_LIMIT;
+    }
+
+    public int getPostPerDayLimit() {
+        return isPremiumUser() ? PREMIUM_USER_POST_PER_DAY_LIMIT : REGISTERED_USER_POST_PER_DAY_LIMIT;
     }
 }

--- a/src/main/java/com/safetypin/post/repository/PostRepository.java
+++ b/src/main/java/com/safetypin/post/repository/PostRepository.java
@@ -4,6 +4,8 @@ import com.safetypin.post.model.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -17,4 +19,7 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
     List<Post> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 
     Page<Post> findByPostedByOrderByCreatedAtDesc(UUID postedBy, Pageable pageable);
+
+    @Query("SELECT COUNT(p) FROM Post p WHERE p.postedBy = :userId AND CAST(p.createdAt AS date) = CURRENT_DATE")
+    int countPostsByUserToday(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/safetypin/post/service/PostService.java
+++ b/src/main/java/com/safetypin/post/service/PostService.java
@@ -1,10 +1,18 @@
 package com.safetypin.post.service;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
+import com.safetypin.post.dto.*;
+import com.safetypin.post.exception.InvalidPostDataException;
+import com.safetypin.post.exception.PostException;
+import com.safetypin.post.exception.PostNotFoundException;
+import com.safetypin.post.exception.UnauthorizedAccessException;
+import com.safetypin.post.model.Category;
+import com.safetypin.post.model.Post;
+import com.safetypin.post.repository.CategoryRepository;
+import com.safetypin.post.repository.PostRepository;
+import com.safetypin.post.service.strategy.DistanceFeedStrategy;
+import com.safetypin.post.service.strategy.FeedStrategy;
+import com.safetypin.post.service.strategy.TimestampFeedStrategy;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
@@ -19,24 +27,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
-import com.safetypin.post.dto.FeedQueryDTO;
-import com.safetypin.post.dto.PostCreateRequest;
-import com.safetypin.post.dto.PostData;
-import com.safetypin.post.dto.PostedByData;
-import com.safetypin.post.dto.UserDetails;
-import com.safetypin.post.exception.InvalidPostDataException;
-import com.safetypin.post.exception.PostException;
-import com.safetypin.post.exception.PostNotFoundException;
-import com.safetypin.post.exception.UnauthorizedAccessException;
-import com.safetypin.post.model.Category;
-import com.safetypin.post.model.Post;
-import com.safetypin.post.repository.CategoryRepository;
-import com.safetypin.post.repository.PostRepository;
-import com.safetypin.post.service.strategy.DistanceFeedStrategy;
-import com.safetypin.post.service.strategy.FeedStrategy;
-import com.safetypin.post.service.strategy.TimestampFeedStrategy;
-
-import lombok.extern.slf4j.Slf4j;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -51,8 +45,8 @@ public class PostService {
 
     @Autowired
     public PostService(PostRepository postRepository, CategoryRepository categoryRepository,
-            DistanceFeedStrategy distanceFeedStrategy,
-            TimestampFeedStrategy timestampFeedStrategy) {
+                       DistanceFeedStrategy distanceFeedStrategy,
+                       TimestampFeedStrategy timestampFeedStrategy) {
         this.postRepository = postRepository;
         this.categoryRepository = categoryRepository;
         this.distanceFeedStrategy = distanceFeedStrategy;
@@ -85,6 +79,13 @@ public class PostService {
         // Validate post data
         validatePostData(title, content, latitude, longitude, category, postedBy, userDetails);
 
+        // check if user has reached the daily post limit
+        long postsToday = postRepository.countPostsByUserToday(userDetails.getUserId());
+        int postLimit = userDetails.getPostPerDayLimit();
+        if (postsToday >= postLimit) {
+            throw new InvalidPostDataException("You have reached your daily post limit of " + postLimit + " posts.");
+        }
+
         // Create and save the post
         return createAndSavePost(postCreateRequest);
     }
@@ -95,7 +96,7 @@ public class PostService {
     }
 
     private void validatePostData(String title, String content, Double latitude, Double longitude,
-            String category, UUID postedBy, UserDetails userDetails) {
+                                  String category, UUID postedBy, UserDetails userDetails) {
         validateTitleAndContent(title, content, userDetails);
         validateLocation(latitude, longitude);
         validateCategoryAndUser(category, postedBy);

--- a/src/test/java/com/safetypin/post/dto/UserDetailsTest.java
+++ b/src/test/java/com/safetypin/post/dto/UserDetailsTest.java
@@ -45,7 +45,7 @@ class UserDetailsTest {
         // Arrange
         UUID testUserId = UUID.randomUUID();
         Claims claims = new DefaultClaims();
-        claims.put("role", Role.REGISTERED_USER);
+        claims.put("role", Role.REGISTERED_USER.name());
         claims.put("isVerified", true);
         claims.put("userId", testUserId.toString());
         claims.put("name", "John Doe");
@@ -64,7 +64,7 @@ class UserDetailsTest {
     void testFromClaimsWithMissingValues() {
         // Arrange
         Claims claims = new DefaultClaims();
-        claims.put("role", Role.REGISTERED_USER);
+        claims.put("role", Role.REGISTERED_USER.name());
         // Omit isVerified
         claims.put("userId", UUID.randomUUID().toString());
         claims.put("name", "John Doe");
@@ -77,7 +77,7 @@ class UserDetailsTest {
     void testFromClaimsWithWrongTypes() {
         // Arrange
         Claims claims = new DefaultClaims();
-        claims.put("role", Role.REGISTERED_USER);
+        claims.put("role", Role.REGISTERED_USER.name());
         claims.put("isVerified", "not-a-boolean"); // Wrong type
         claims.put("userId", UUID.randomUUID().toString());
         claims.put("name", "John Doe");
@@ -90,7 +90,7 @@ class UserDetailsTest {
     void testFromClaimsWithInvalidUserId() {
         // Arrange
         Claims claims = new DefaultClaims();
-        claims.put("role", Role.REGISTERED_USER);
+        claims.put("role", Role.REGISTERED_USER.name());
         claims.put("isVerified", true);
         claims.put("userId", "not-a-uuid"); // Invalid UUID
         claims.put("name", "John Doe");

--- a/src/test/java/com/safetypin/post/security/JWTFilterTest.java
+++ b/src/test/java/com/safetypin/post/security/JWTFilterTest.java
@@ -1,16 +1,12 @@
 package com.safetypin.post.security;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.UUID;
-
+import com.safetypin.post.dto.UserDetails;
+import com.safetypin.post.model.Role;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -20,14 +16,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import com.safetypin.post.dto.UserDetails;
-import com.safetypin.post.model.Role;
+import java.io.IOException;
+import java.util.UUID;
 
-import io.jsonwebtoken.Claims;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class JWTFilterTest {
 
@@ -58,7 +51,7 @@ class JWTFilterTest {
         when(request.getHeader("Authorization")).thenReturn("Bearer " + testToken);
         when(jwtUtil.verifyAndGetClaims(testToken)).thenReturn(claims);
 
-        when(claims.get("role", Role.class)).thenReturn(Role.REGISTERED_USER);
+        when(claims.get("role", String.class)).thenReturn(Role.REGISTERED_USER.name());
         when(claims.get("isVerified", Boolean.class)).thenReturn(true);
         when(claims.get("userId", String.class)).thenReturn(testUserId.toString());
         when(claims.get("name", String.class)).thenReturn("John Doe");
@@ -147,7 +140,7 @@ class JWTFilterTest {
         when(jwtUtil.verifyAndGetClaims(testToken)).thenReturn(claims);
 
         // Missing required claim
-        when(claims.get("role", Role.class)).thenReturn(Role.MODERATOR);
+        when(claims.get("role", String.class)).thenReturn(Role.MODERATOR.name());
         when(claims.get("isVerified", Boolean.class)).thenReturn(null); // This will cause NullPointerException
         when(claims.get("userId", String.class)).thenReturn(testUserId.toString());
         when(claims.get("name", String.class)).thenReturn("Moderator User");
@@ -168,7 +161,7 @@ class JWTFilterTest {
         when(jwtUtil.verifyAndGetClaims(testToken)).thenReturn(claims);
 
         // Invalid UUID format
-        when(claims.get("role", Role.class)).thenReturn(Role.REGISTERED_USER);
+        when(claims.get("role", String.class)).thenReturn(Role.REGISTERED_USER.name());
         when(claims.get("isVerified", Boolean.class)).thenReturn(true);
         when(claims.get("userId", String.class)).thenReturn("not-a-valid-uuid");
         when(claims.get("name", String.class)).thenReturn("John Doe");
@@ -188,7 +181,7 @@ class JWTFilterTest {
         when(request.getHeader("Authorization")).thenReturn("Bearer " + testToken);
         when(jwtUtil.verifyAndGetClaims(testToken)).thenReturn(claims);
 
-        when(claims.get("role", Role.class)).thenReturn(Role.MODERATOR);
+        when(claims.get("role", String.class)).thenReturn(Role.MODERATOR.name());
         when(claims.get("isVerified", Boolean.class)).thenReturn(true);
         when(claims.get("userId", String.class)).thenReturn(testUserId.toString());
         when(claims.get("name", String.class)).thenReturn("Moderator User");


### PR DESCRIPTION
Implemented limit post per day based on user's role:
- REGISTERED_USER -> 3 posts/day
- PREMIUM_USER/MODERATOR -> 10 posts/day
On every post creation request, it will use native query to count posts that's already created by that user in the same day. There's no need of connection with be-auth.

p.s. I put the limit in small numbers to ease debugging