### PR TITLE
Depol/comment notification

### DIFF
--- a/src/main/java/com/safetypin/post/controller/CommentNotificationController.java
+++ b/src/main/java/com/safetypin/post/controller/CommentNotificationController.java
@@ -1,0 +1,63 @@
+package com.safetypin.post.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.safetypin.post.dto.NotificationDto;
+import com.safetypin.post.dto.PostResponse;
+import com.safetypin.post.dto.UserDetails;
+import com.safetypin.post.service.NotificationService;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/comment-notifications") // Updated mapping
+@AllArgsConstructor
+public class CommentNotificationController { // Renamed controller
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<PostResponse> getCommentNotifications() { // Renamed method for clarity
+        try {
+            // Get user details from security context
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            UUID userId = userDetails.getUserId();
+
+            log.info("Fetching comment notifications for user ID: {}", userId);
+
+            List<NotificationDto> notifications = notificationService.getNotifications(userId);
+
+            PostResponse response = new PostResponse(true, "Comment notifications retrieved successfully",
+                    notifications);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(response);
+
+        } catch (Exception e) {
+            log.error("Error fetching comment notifications: {}", e.getMessage(), e);
+            return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to retrieve comment notifications: " + e.getMessage());
+        }
+    }
+
+    // Helper method to create error responses
+    private ResponseEntity<PostResponse> createErrorResponse(HttpStatus status, String message) {
+        PostResponse errorResponse = new PostResponse(false, message, null);
+        return ResponseEntity.status(status)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/com/safetypin/post/dto/NotificationDto.java
+++ b/src/main/java/com/safetypin/post/dto/NotificationDto.java
@@ -1,0 +1,27 @@
+package com.safetypin.post.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.safetypin.post.model.NotificationType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationDto {
+    private NotificationType type;
+    private UUID actorUserId; // The user who performed the action (commented/replied)
+    private String actorName;
+    private String actorProfilePictureUrl;
+    private String timeAgo;
+    private UUID postId;
+    private UUID commentId; // ID of the parent comment (for replies or sibling replies)
+    private UUID replyId; // ID of the specific reply (for NEW_REPLY* or NEW_SIBLING_REPLY)
+    private LocalDateTime createdAt; // Keep original timestamp for sorting
+}

--- a/src/main/java/com/safetypin/post/dto/UserInfoDto.java
+++ b/src/main/java/com/safetypin/post/dto/UserInfoDto.java
@@ -1,0 +1,16 @@
+package com.safetypin.post.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoDto {
+    private UUID userId;
+    private String name;
+    private String profilePictureUrl; // Assuming the auth service provides a URL
+}

--- a/src/main/java/com/safetypin/post/model/NotificationType.java
+++ b/src/main/java/com/safetypin/post/model/NotificationType.java
@@ -1,0 +1,7 @@
+package com.safetypin.post.model;
+
+public enum NotificationType {
+    NEW_COMMENT_ON_POST, // Someone commented on your post
+    NEW_REPLY_TO_COMMENT, // Someone replied to your comment
+    NEW_SIBLING_REPLY // Someone else replied to the same comment thread you are in
+}

--- a/src/main/java/com/safetypin/post/repository/CommentOnCommentRepository.java
+++ b/src/main/java/com/safetypin/post/repository/CommentOnCommentRepository.java
@@ -1,13 +1,31 @@
 package com.safetypin.post.repository;
 
-import com.safetypin.post.model.CommentOnComment;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.safetypin.post.model.CommentOnComment;
 
 @Repository
 public interface CommentOnCommentRepository extends JpaRepository<CommentOnComment, UUID> {
     List<CommentOnComment> findByParentId(UUID parentId);
+
+    // Find replies to comments owned by a specific user within a time range
+    @Query("SELECT r FROM CommentOnComment r WHERE r.parent.postedBy = :userId AND r.postedBy <> :userId AND r.createdAt >= :since")
+    List<CommentOnComment> findRepliesToUserCommentsSince(@Param("userId") UUID userId,
+            @Param("since") LocalDateTime since);
+
+    // Find replies made by a specific user within a time range
+    List<CommentOnComment> findByPostedByAndCreatedAtGreaterThanEqual(UUID postedBy, LocalDateTime since);
+
+    // Find replies by others on the same parent comment where the user also
+    // replied, within a time range
+    @Query("SELECT r FROM CommentOnComment r WHERE r.parent.id IN :parentCommentIds AND r.postedBy <> :userId AND r.createdAt >= :since")
+    List<CommentOnComment> findSiblingRepliesSince(@Param("userId") UUID userId,
+            @Param("parentCommentIds") List<UUID> parentCommentIds, @Param("since") LocalDateTime since);
 }

--- a/src/main/java/com/safetypin/post/repository/CommentOnPostRepository.java
+++ b/src/main/java/com/safetypin/post/repository/CommentOnPostRepository.java
@@ -1,13 +1,24 @@
 package com.safetypin.post.repository;
 
-import com.safetypin.post.model.CommentOnPost;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.safetypin.post.model.CommentOnPost;
 
 @Repository
 public interface CommentOnPostRepository extends JpaRepository<CommentOnPost, UUID> {
     List<CommentOnPost> findByParentId(UUID parentId);
+
+    // Find comments on posts owned by a specific user within a time range
+    @Query("SELECT c FROM CommentOnPost c WHERE c.parent.postedBy = :userId AND c.postedBy <> :userId AND c.createdAt >= :since")
+    List<CommentOnPost> findCommentsOnUserPostsSince(@Param("userId") UUID userId, @Param("since") LocalDateTime since);
+
+    // Find comments made by a specific user within a time range
+    List<CommentOnPost> findByPostedByAndCreatedAtGreaterThanEqual(UUID postedBy, LocalDateTime since);
 }

--- a/src/main/java/com/safetypin/post/service/NotificationService.java
+++ b/src/main/java/com/safetypin/post/service/NotificationService.java
@@ -1,0 +1,20 @@
+package com.safetypin.post.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.safetypin.post.dto.NotificationDto;
+
+@Service
+public interface NotificationService {
+    /**
+     * Retrieves notifications for a given user within the last 30 days.
+     *
+     * @param userId The ID of the user for whom to fetch notifications.
+     * @return A list of NotificationDto objects, sorted by creation time
+     *         descending.
+     */
+    List<NotificationDto> getNotifications(UUID userId);
+}

--- a/src/main/java/com/safetypin/post/service/NotificationServiceImpl.java
+++ b/src/main/java/com/safetypin/post/service/NotificationServiceImpl.java
@@ -1,0 +1,195 @@
+package com.safetypin.post.service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.safetypin.post.dto.NotificationDto;
+import com.safetypin.post.dto.PostedByData; // Using PostedByData as it seems to be the existing DTO for profile info
+import com.safetypin.post.model.CommentOnComment;
+import com.safetypin.post.model.CommentOnPost;
+import com.safetypin.post.model.NotificationType;
+import com.safetypin.post.repository.CommentOnCommentRepository;
+import com.safetypin.post.repository.CommentOnPostRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationServiceImpl implements NotificationService {
+
+        private final CommentOnPostRepository commentOnPostRepository;
+        private final CommentOnCommentRepository commentOnCommentRepository;
+        private final RestTemplate restTemplate;
+
+        @Value("${be-auth.base-url}") // Use a base URL property
+        private String authServiceBaseUrl;
+
+        private static final String PROFILE_BATCH_PATH = "/api/profiles/batch";
+
+        @Override
+        public List<NotificationDto> getNotifications(UUID userId) {
+                LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+                Set<UUID> actorIds = new HashSet<>();
+
+                // 1. NEW_COMMENT_ON_POST: Someone commented on your post
+                List<CommentOnPost> commentsOnUserPosts = commentOnPostRepository.findCommentsOnUserPostsSince(userId,
+                                thirtyDaysAgo);
+                commentsOnUserPosts.forEach(c -> actorIds.add(c.getPostedBy()));
+
+                // 2. NEW_REPLY_TO_COMMENT: Someone replied to your comment (your comment is
+                // CommentOnPost)
+                List<CommentOnComment> repliesToUserComments = commentOnCommentRepository
+                                .findRepliesToUserCommentsSince(userId,
+                                                thirtyDaysAgo);
+                repliesToUserComments.forEach(r -> actorIds.add(r.getPostedBy()));
+
+                // 3. NEW_SIBLING_REPLY: Someone else replied to the same comment thread you are
+                // in
+                List<CommentOnComment> userReplies = commentOnCommentRepository
+                                .findByPostedByAndCreatedAtGreaterThanEqual(userId, thirtyDaysAgo);
+                List<UUID> parentCommentIdsUserRepliedTo = userReplies.stream()
+                                .map(reply -> reply.getParent().getId())
+                                .distinct()
+                                .toList();
+
+                List<CommentOnComment> siblingReplies = Collections.emptyList();
+                if (!parentCommentIdsUserRepliedTo.isEmpty()) {
+                        siblingReplies = commentOnCommentRepository.findSiblingRepliesSince(userId,
+                                        parentCommentIdsUserRepliedTo,
+                                        thirtyDaysAgo);
+                        siblingReplies.forEach(r -> actorIds.add(r.getPostedBy()));
+                }
+
+                // Fetch user info for all actors in bulk using the correct endpoint and method
+                Map<UUID, PostedByData> userInfoMap = fetchUserDetailsBatch(new ArrayList<>(actorIds));
+
+                // Map to DTOs
+                Stream<NotificationDto> commentsOnPostNotifications = commentsOnUserPosts.stream()
+                                .map(comment -> createNotificationDto(
+                                                NotificationType.NEW_COMMENT_ON_POST,
+                                                comment.getPostedBy(),
+                                                userInfoMap.get(comment.getPostedBy()),
+                                                comment.getCreatedAt(),
+                                                comment.getParent().getId(), // postId
+                                                comment.getId(), // commentId
+                                                null // replyId
+                                ));
+
+                Stream<NotificationDto> repliesToCommentNotifications = repliesToUserComments.stream()
+                                .map(reply -> createNotificationDto(
+                                                NotificationType.NEW_REPLY_TO_COMMENT,
+                                                reply.getPostedBy(),
+                                                userInfoMap.get(reply.getPostedBy()),
+                                                reply.getCreatedAt(),
+                                                reply.getParent().getParent().getId(), // postId
+                                                reply.getParent().getId(), // commentId (parent of the reply)
+                                                reply.getId() // replyId
+                                ));
+
+                Stream<NotificationDto> siblingReplyNotifications = siblingReplies.stream()
+                                .map(reply -> createNotificationDto(
+                                                NotificationType.NEW_SIBLING_REPLY,
+                                                reply.getPostedBy(),
+                                                userInfoMap.get(reply.getPostedBy()),
+                                                reply.getCreatedAt(),
+                                                reply.getParent().getParent().getId(), // postId
+                                                reply.getParent().getId(), // commentId (parent of the reply)
+                                                reply.getId() // replyId
+                                ));
+
+                // Combine, sort, and return
+                return Stream.of(commentsOnPostNotifications, repliesToCommentNotifications, siblingReplyNotifications)
+                                .flatMap(Function.identity())
+                                .sorted(Comparator.comparing(NotificationDto::getCreatedAt).reversed())
+                                .toList();
+        }
+
+        private NotificationDto createNotificationDto(NotificationType type, UUID actorId, PostedByData actorInfo,
+                        LocalDateTime createdAt, UUID postId, UUID commentId, UUID replyId) {
+                String actorName = actorInfo != null ? actorInfo.getName() : "Unknown User";
+                String actorProfilePic = actorInfo != null ? actorInfo.getProfilePicture() : null; // Assuming
+                                                                                                   // PostedByData has
+                                                                                                   // getProfilePicture()
+
+                return NotificationDto.builder()
+                                .type(type)
+                                .actorUserId(actorId)
+                                .actorName(actorName)
+                                .actorProfilePictureUrl(actorProfilePic)
+                                .timeAgo(calculateDaysAgo(createdAt)) // Use days ago calculation
+                                .postId(postId)
+                                .commentId(commentId)
+                                .replyId(replyId)
+                                .createdAt(createdAt) // Keep original timestamp for sorting
+                                .build();
+        }
+
+        // Updated method to fetch user details using POST /api/profiles/batch
+        private Map<UUID, PostedByData> fetchUserDetailsBatch(List<UUID> userIds) {
+                if (userIds == null || userIds.isEmpty()) {
+                        return Collections.emptyMap();
+                }
+
+                String uri = authServiceBaseUrl + PROFILE_BATCH_PATH;
+                HttpEntity<List<UUID>> entity = new HttpEntity<>(userIds, null); // Send list of UUIDs in the body
+
+                try {
+                        ResponseEntity<Map<UUID, PostedByData>> response = restTemplate.exchange(
+                                        uri,
+                                        HttpMethod.POST, // Use POST method
+                                        entity,
+                                        new ParameterizedTypeReference<Map<UUID, PostedByData>>() {
+                                        }); // Expecting Map<UUID, PostedByData>
+
+                        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                                log.info("Fetched {} profiles successfully via POST {}.", response.getBody().size(),
+                                                uri);
+                                return response.getBody();
+                        } else {
+                                log.error("Failed to fetch user details from Auth service via POST {}. Status: {}, Body: {}",
+                                                uri,
+                                                response.getStatusCode(), response.getBody());
+                        }
+                } catch (ResourceAccessException e) {
+                        log.error("Network error fetching profiles via POST {} for user IDs {}: {}", uri, userIds,
+                                        e.getMessage());
+                } catch (Exception e) {
+                        log.error("Error fetching profiles via POST {} for user IDs {}: {}", uri, userIds,
+                                        e.getMessage(), e);
+                }
+                return Collections.emptyMap(); // Return empty map on failure
+        }
+
+        // Calculate days ago
+        private String calculateDaysAgo(LocalDateTime pastTime) {
+                long days = ChronoUnit.DAYS.between(pastTime.toLocalDate(), LocalDateTime.now().toLocalDate());
+                if (days == 0) {
+                        return "Today";
+                } else if (days == 1) {
+                        return "1 day ago";
+                } else {
+                        return days + " days ago";
+                }
+        }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,9 @@ aws.s3.region=ap-southeast-2
 jwt.secret=${JWT_SECRET_KEY:wjii9rguinj3k4kiwedsiuonj32jiiew99ij324rjifsnf}
 management.endpoints.web.exposure.include=health,prometheus
 management.prometheus.metrics.export.enabled=true
+
+# Auth Service Configuration
+# Use a base URL property
+be-auth.base-url=http://localhost:8080
+# If your auth service is deployed elsewhere, use that URL:
+# be-auth.base-url=http://safetypin.ppl.cs.ui.ac.id

--- a/src/test/java/com/safetypin/post/controller/CommentNotificationControllerTest.java
+++ b/src/test/java/com/safetypin/post/controller/CommentNotificationControllerTest.java
@@ -1,0 +1,180 @@
+package com.safetypin.post.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.safetypin.post.dto.NotificationDto;
+import com.safetypin.post.dto.PostResponse;
+import com.safetypin.post.dto.UserDetails;
+import com.safetypin.post.model.NotificationType;
+import com.safetypin.post.model.Role;
+import com.safetypin.post.service.NotificationService;
+
+@ExtendWith(MockitoExtension.class)
+class CommentNotificationControllerTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private CommentNotificationController commentNotificationController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private UUID testUserId;
+    private UserDetails testUserDetails;
+    private String testUserName = "testuser";
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(commentNotificationController).build();
+        testUserId = UUID.randomUUID();
+        testUserDetails = new UserDetails(Role.REGISTERED_USER, true, testUserId, testUserName);
+
+        // Mock SecurityContext
+        Authentication authentication = new UsernamePasswordAuthenticationToken(testUserDetails, null,
+                Collections.emptyList());
+        SecurityContext securityContext = mock(SecurityContext.class);
+
+        // Using lenient() to avoid UnnecessaryStubbingException for tests that clear
+        // the security context
+        lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Test
+    void getCommentNotifications_Success() throws Exception {
+        // Arrange
+        UUID actorId = UUID.randomUUID();
+        NotificationDto notification = NotificationDto.builder()
+                .type(NotificationType.NEW_COMMENT_ON_POST)
+                .actorUserId(actorId)
+                .actorName("Actor User")
+                .actorProfilePictureUrl("http://example.com/pic.jpg")
+                .timeAgo("Today")
+                .postId(UUID.randomUUID())
+                .commentId(UUID.randomUUID())
+                .createdAt(LocalDateTime.now())
+                .build();
+        List<NotificationDto> notifications = List.of(notification);
+        PostResponse expectedResponse = new PostResponse(true, "Comment notifications retrieved successfully",
+                notifications);
+
+        when(notificationService.getNotifications(testUserId)).thenReturn(notifications);
+
+        // Act & Assert
+        mockMvc.perform(get("/comment-notifications")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Comment notifications retrieved successfully"))
+                .andExpect(jsonPath("$.data[0].type").value(NotificationType.NEW_COMMENT_ON_POST.toString()))
+                .andExpect(jsonPath("$.data[0].actorUserId").value(actorId.toString()))
+                .andExpect(jsonPath("$.data[0].actorName").value("Actor User"));
+
+        verify(notificationService, times(1)).getNotifications(testUserId);
+    }
+
+    @Test
+    void getCommentNotifications_ServiceThrowsException() throws Exception {
+        // Arrange
+        String errorMessage = "Database connection failed";
+        when(notificationService.getNotifications(testUserId)).thenThrow(new RuntimeException(errorMessage));
+
+        // Act & Assert
+        mockMvc.perform(get("/comment-notifications")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Failed to retrieve comment notifications: " + errorMessage))
+                .andExpect(jsonPath("$.data").doesNotExist()); // Or .isEmpty() depending on PostResponse structure
+
+        verify(notificationService, times(1)).getNotifications(testUserId);
+    }
+
+    @Test
+    void getCommentNotifications_NoNotificationsFound() throws Exception {
+        // Arrange
+        when(notificationService.getNotifications(testUserId)).thenReturn(Collections.emptyList());
+        PostResponse expectedResponse = new PostResponse(true, "Comment notifications retrieved successfully",
+                Collections.emptyList());
+
+        // Act & Assert
+        mockMvc.perform(get("/comment-notifications")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Comment notifications retrieved successfully"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(notificationService, times(1)).getNotifications(testUserId);
+    }
+
+    @Test
+    void getCommentNotifications_Unauthenticated() throws Exception {
+        // Arrange - Clear security context for this test
+        SecurityContextHolder.clearContext();
+
+        // Act & Assert
+        // Standalone setup doesn't automatically enforce security rules like full
+        // context testing.
+        // This test primarily ensures the controller code handles missing auth
+        // gracefully *if* accessed,
+        // though typically Spring Security filters would block unauthenticated requests
+        // earlier.
+        // We expect a NullPointerException here because the controller tries to
+        // getPrincipal() on null auth.
+        // A real Spring Security setup would return 401/403 before reaching the
+        // controller.
+        // For unit testing the controller logic *after* auth, we assume auth succeeded
+        // (like in setUp).
+        // To test the *absence* of auth leading to an error *within* the controller:
+        try {
+            commentNotificationController.getCommentNotifications();
+        } catch (NullPointerException e) {
+            // Expected because SecurityContextHolder.getContext().getAuthentication() is
+            // null
+        }
+
+        // We don't verify notificationService because the controller should fail before
+        // calling it.
+        verify(notificationService, never()).getNotifications(any());
+
+        // A more integrated test with MockMvc and Spring Security would look like:
+        // mockMvc.perform(get("/comment-notifications"))
+        // .andExpect(status().isUnauthorized()); // Or isForbidden()
+    }
+}

--- a/src/test/java/com/safetypin/post/service/strategy/NotificationServiceTest.java
+++ b/src/test/java/com/safetypin/post/service/strategy/NotificationServiceTest.java
@@ -1,0 +1,602 @@
+package com.safetypin.post.service.strategy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.safetypin.post.dto.NotificationDto;
+import com.safetypin.post.dto.PostedByData;
+import com.safetypin.post.model.CommentOnComment;
+import com.safetypin.post.model.CommentOnPost;
+import com.safetypin.post.model.NotificationType;
+import com.safetypin.post.model.Post;
+import com.safetypin.post.repository.CommentOnCommentRepository;
+import com.safetypin.post.repository.CommentOnPostRepository;
+import com.safetypin.post.service.NotificationServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+
+        @Mock
+        private CommentOnPostRepository commentOnPostRepository;
+        @Mock
+        private CommentOnCommentRepository commentOnCommentRepository;
+        @Mock
+        private RestTemplate restTemplate;
+
+        @InjectMocks
+        private NotificationServiceImpl notificationService;
+
+        private UUID testUserId;
+        private UUID actor1Id;
+        private UUID actor2Id;
+        private UUID postId;
+        private UUID commentOnPostId;
+        private UUID commentOnCommentId;
+        private LocalDateTime now;
+        private LocalDateTime thirtyDaysAgo;
+        private Post post;
+        private CommentOnPost parentComment; // User's comment
+
+        @BeforeEach
+        void setUp() {
+                testUserId = UUID.randomUUID();
+                actor1Id = UUID.randomUUID();
+                actor2Id = UUID.randomUUID();
+                postId = UUID.randomUUID();
+                commentOnPostId = UUID.randomUUID(); // ID of the user's comment
+                commentOnCommentId = UUID.randomUUID();
+                now = LocalDateTime.now();
+                thirtyDaysAgo = now.minusDays(30);
+
+                // Set base URL via reflection as it's @Value injected
+                ReflectionTestUtils.setField(notificationService, "authServiceBaseUrl", "http://fake-auth-service");
+
+                // Common entities
+                post = new Post();
+                post.setId(postId);
+                post.setPostedBy(testUserId); // Post owned by the user
+
+                parentComment = new CommentOnPost();
+                parentComment.setId(commentOnPostId);
+                parentComment.setPostedBy(testUserId); // Comment owned by the user
+                parentComment.setParent(post);
+                parentComment.setCreatedAt(now.minusDays(5));
+        }
+
+        // Helper to create CommentOnPost
+        private CommentOnPost createCommentOnPost(UUID id, UUID actorId, Post parentPost, LocalDateTime createdAt) {
+                CommentOnPost comment = new CommentOnPost();
+                comment.setId(id);
+                comment.setPostedBy(actorId);
+                comment.setParent(parentPost);
+                comment.setCreatedAt(createdAt);
+                return comment;
+        }
+
+        // Helper to create CommentOnComment
+        private CommentOnComment createCommentOnComment(UUID id, UUID actorId, CommentOnPost parentComment,
+                        LocalDateTime createdAt) {
+                CommentOnComment reply = new CommentOnComment();
+                reply.setId(id);
+                reply.setPostedBy(actorId);
+                reply.setParent(parentComment);
+                reply.setCreatedAt(createdAt);
+                return reply;
+        }
+
+        // Helper to mock the successful auth service response
+        private void mockAuthServiceResponse(Map<UUID, PostedByData> responseMap) {
+                ResponseEntity<Map<UUID, PostedByData>> responseEntity = new ResponseEntity<>(responseMap,
+                                HttpStatus.OK);
+                when(restTemplate.exchange(
+                                eq("http://fake-auth-service/api/profiles/batch"),
+                                eq(HttpMethod.POST),
+                                any(HttpEntity.class), // Match any HttpEntity containing the list of UUIDs
+                                any(ParameterizedTypeReference.class))) // Match the specific ParameterizedTypeReference
+                                .thenReturn(responseEntity);
+        }
+
+        // Helper to mock auth service failure
+        private void mockAuthServiceFailure(Exception exception) {
+                when(restTemplate.exchange(
+                                eq("http://fake-auth-service/api/profiles/batch"),
+                                eq(HttpMethod.POST),
+                                any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class)))
+                                .thenThrow(exception);
+        }
+
+        @Test
+        void getNotifications_AllTypes_Success() {
+                // Arrange
+                // 1. Comment on user's post (actor1)
+                CommentOnPost commentOnUserPost = createCommentOnPost(UUID.randomUUID(), actor1Id, post,
+                                now.minusDays(1));
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(List.of(commentOnUserPost));
+
+                // 2. Reply to user's comment (actor2)
+                CommentOnComment replyToUserComment = createCommentOnComment(UUID.randomUUID(), actor2Id, parentComment,
+                                now.minusDays(2));
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(List.of(replyToUserComment));
+
+                // 3. Sibling reply (actor1 replies to same comment user replied to)
+                CommentOnComment userReply = createCommentOnComment(UUID.randomUUID(), testUserId, parentComment,
+                                now.minusDays(4)); // User replied first
+                CommentOnComment siblingReply = createCommentOnComment(UUID.randomUUID(), actor1Id, parentComment,
+                                now.minusDays(3)); // Actor1 replied later
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(List.of(userReply)); // User has replied
+                when(commentOnCommentRepository.findSiblingRepliesSince(eq(testUserId),
+                                eq(List.of(parentComment.getId())),
+                                any(LocalDateTime.class)))
+                                .thenReturn(List.of(siblingReply)); // Actor1's reply is found
+
+                // Mock Auth Service response for actor1 and actor2
+                Map<UUID, PostedByData> userInfoMap = new HashMap<>();
+                userInfoMap.put(actor1Id, new PostedByData(actor1Id, "Actor One", "pic1.jpg"));
+                userInfoMap.put(actor2Id, new PostedByData(actor2Id, "Actor Two", "pic2.jpg"));
+                mockAuthServiceResponse(userInfoMap);
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert
+                assertEquals(3, notifications.size());
+                // Verify sorting (most recent first) and content
+                // Notification 1: Comment on Post (actor1, 1 day ago)
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(0).getType());
+                assertEquals(actor1Id, notifications.get(0).getActorUserId());
+                assertEquals("Actor One", notifications.get(0).getActorName());
+                assertEquals("pic1.jpg", notifications.get(0).getActorProfilePictureUrl());
+                assertEquals("1 day ago", notifications.get(0).getTimeAgo());
+                assertEquals(postId, notifications.get(0).getPostId());
+                assertEquals(commentOnUserPost.getId(), notifications.get(0).getCommentId());
+                assertNull(notifications.get(0).getReplyId());
+
+                // Notification 2: Reply to Comment (actor2, 2 days ago)
+                assertEquals(NotificationType.NEW_REPLY_TO_COMMENT, notifications.get(1).getType());
+                assertEquals(actor2Id, notifications.get(1).getActorUserId());
+                assertEquals("Actor Two", notifications.get(1).getActorName());
+                assertEquals("pic2.jpg", notifications.get(1).getActorProfilePictureUrl());
+                assertEquals("2 days ago", notifications.get(1).getTimeAgo());
+                assertEquals(postId, notifications.get(1).getPostId());
+                assertEquals(parentComment.getId(), notifications.get(1).getCommentId());
+                assertEquals(replyToUserComment.getId(), notifications.get(1).getReplyId());
+
+                // Notification 3: Sibling Reply (actor1, 3 days ago)
+                assertEquals(NotificationType.NEW_SIBLING_REPLY, notifications.get(2).getType());
+                assertEquals(actor1Id, notifications.get(2).getActorUserId());
+                assertEquals("Actor One", notifications.get(2).getActorName()); // Reused info
+                assertEquals("pic1.jpg", notifications.get(2).getActorProfilePictureUrl());
+                assertEquals("3 days ago", notifications.get(2).getTimeAgo());
+                assertEquals(postId, notifications.get(2).getPostId());
+                assertEquals(parentComment.getId(), notifications.get(2).getCommentId());
+                assertEquals(siblingReply.getId(), notifications.get(2).getReplyId());
+
+                // Verify repository calls
+                verify(commentOnPostRepository, times(1)).findCommentsOnUserPostsSince(eq(testUserId),
+                                any(LocalDateTime.class));
+                verify(commentOnCommentRepository, times(1)).findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class));
+                verify(commentOnCommentRepository, times(1)).findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class));
+                verify(commentOnCommentRepository, times(1)).findSiblingRepliesSince(eq(testUserId),
+                                eq(List.of(parentComment.getId())), any(LocalDateTime.class));
+                // Verify auth service call
+                verify(restTemplate, times(1)).exchange(
+                                eq("http://fake-auth-service/api/profiles/batch"),
+                                eq(HttpMethod.POST),
+                                argThat(entity -> entity != null && entity.getBody() instanceof List
+                                                && ((List<?>) entity.getBody())
+                                                                .containsAll(List.of(actor1Id, actor2Id))),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_OnlyCommentsOnPost() {
+                // Arrange
+                CommentOnPost comment1 = createCommentOnPost(UUID.randomUUID(), actor1Id, post, now.minusDays(1));
+                CommentOnPost comment2 = createCommentOnPost(UUID.randomUUID(), actor2Id, post, now.minusDays(5));
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(List.of(comment1, comment2));
+                // No replies or sibling replies
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                // findSiblingRepliesSince won't be called if findByPostedBy... returns empty
+
+                Map<UUID, PostedByData> userInfoMap = new HashMap<>();
+                userInfoMap.put(actor1Id, new PostedByData(actor1Id, "Actor One", "pic1.jpg"));
+                userInfoMap.put(actor2Id, new PostedByData(actor2Id, "Actor Two", "pic2.jpg"));
+                mockAuthServiceResponse(userInfoMap);
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert
+                assertEquals(2, notifications.size());
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(0).getType());
+                assertEquals(actor1Id, notifications.get(0).getActorUserId());
+                assertEquals("1 day ago", notifications.get(0).getTimeAgo());
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(1).getType());
+                assertEquals(actor2Id, notifications.get(1).getActorUserId());
+                assertEquals("5 days ago", notifications.get(1).getTimeAgo());
+
+                verify(commentOnCommentRepository, never()).findSiblingRepliesSince(any(), any(), any());
+                verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_OnlyRepliesToComment() {
+                // Arrange
+                CommentOnComment reply1 = createCommentOnComment(UUID.randomUUID(), actor1Id, parentComment,
+                                now.minusDays(1));
+                CommentOnComment reply2 = createCommentOnComment(UUID.randomUUID(), actor2Id, parentComment,
+                                now.minusDays(5));
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(List.of(reply1, reply2));
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+
+                Map<UUID, PostedByData> userInfoMap = new HashMap<>();
+                userInfoMap.put(actor1Id, new PostedByData(actor1Id, "Actor One", "pic1.jpg"));
+                userInfoMap.put(actor2Id, new PostedByData(actor2Id, "Actor Two", "pic2.jpg"));
+                mockAuthServiceResponse(userInfoMap);
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert
+                assertEquals(2, notifications.size());
+                assertEquals(NotificationType.NEW_REPLY_TO_COMMENT, notifications.get(0).getType());
+                assertEquals(actor1Id, notifications.get(0).getActorUserId());
+                assertEquals("1 day ago", notifications.get(0).getTimeAgo());
+                assertEquals(NotificationType.NEW_REPLY_TO_COMMENT, notifications.get(1).getType());
+                assertEquals(actor2Id, notifications.get(1).getActorUserId());
+                assertEquals("5 days ago", notifications.get(1).getTimeAgo());
+
+                verify(commentOnCommentRepository, never()).findSiblingRepliesSince(any(), any(), any());
+                verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_OnlySiblingReplies() {
+                // Arrange
+                CommentOnComment userReply = createCommentOnComment(UUID.randomUUID(), testUserId, parentComment,
+                                now.minusDays(4));
+                CommentOnComment siblingReply1 = createCommentOnComment(UUID.randomUUID(), actor1Id, parentComment,
+                                now.minusDays(1));
+                CommentOnComment siblingReply2 = createCommentOnComment(UUID.randomUUID(), actor2Id, parentComment,
+                                now.minusDays(3));
+
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(List.of(userReply)); // User has replied
+                when(commentOnCommentRepository.findSiblingRepliesSince(eq(testUserId),
+                                eq(List.of(parentComment.getId())),
+                                any(LocalDateTime.class)))
+                                .thenReturn(List.of(siblingReply1, siblingReply2)); // Found sibling replies
+
+                Map<UUID, PostedByData> userInfoMap = new HashMap<>();
+                userInfoMap.put(actor1Id, new PostedByData(actor1Id, "Actor One", "pic1.jpg"));
+                userInfoMap.put(actor2Id, new PostedByData(actor2Id, "Actor Two", "pic2.jpg"));
+                mockAuthServiceResponse(userInfoMap);
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert
+                assertEquals(2, notifications.size());
+                assertEquals(NotificationType.NEW_SIBLING_REPLY, notifications.get(0).getType());
+                assertEquals(actor1Id, notifications.get(0).getActorUserId());
+                assertEquals("1 day ago", notifications.get(0).getTimeAgo());
+                assertEquals(NotificationType.NEW_SIBLING_REPLY, notifications.get(1).getType());
+                assertEquals(actor2Id, notifications.get(1).getActorUserId());
+                assertEquals("3 days ago", notifications.get(1).getTimeAgo());
+
+                verify(commentOnCommentRepository, times(1)).findSiblingRepliesSince(eq(testUserId),
+                                eq(List.of(parentComment.getId())), any(LocalDateTime.class));
+                verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_NoNotificationsFound() {
+                // Arrange
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+
+                // No actors, so auth service shouldn't be called
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert
+                assertTrue(notifications.isEmpty());
+                verify(commentOnCommentRepository, never()).findSiblingRepliesSince(any(), any(), any());
+                verify(restTemplate, never()).exchange(anyString(), any(), any(),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_AuthServiceFails_ResourceAccessException() {
+                // Arrange: Setup one notification source
+                CommentOnPost commentOnUserPost = createCommentOnPost(UUID.randomUUID(), actor1Id, post,
+                                now.minusDays(1));
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(List.of(commentOnUserPost));
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+
+                // Mock Auth Service failure
+                mockAuthServiceFailure(new ResourceAccessException("Network error"));
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert: Notification should still be created but with default user info
+                assertEquals(1, notifications.size());
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(0).getType());
+                assertEquals(actor1Id, notifications.get(0).getActorUserId());
+                assertEquals("Unknown User", notifications.get(0).getActorName()); // Defaulted
+                assertNull(notifications.get(0).getActorProfilePictureUrl()); // Defaulted
+                assertEquals("1 day ago", notifications.get(0).getTimeAgo());
+
+                // Verify auth service was called
+                verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_AuthServiceFails_OtherException() {
+                // Arrange: Setup one notification source
+                CommentOnPost commentOnUserPost = createCommentOnPost(UUID.randomUUID(), actor1Id, post,
+                                now.minusDays(1));
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(List.of(commentOnUserPost));
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+
+                // Mock Auth Service failure
+                mockAuthServiceFailure(new RuntimeException("Unexpected error"));
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert: Notification should still be created but with default user info
+                assertEquals(1, notifications.size());
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(0).getType());
+                assertEquals(actor1Id, notifications.get(0).getActorUserId());
+                assertEquals("Unknown User", notifications.get(0).getActorName());
+                assertNull(notifications.get(0).getActorProfilePictureUrl());
+                assertEquals("1 day ago", notifications.get(0).getTimeAgo());
+
+                // Verify auth service was called
+                verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_AuthServiceReturnsPartialData() {
+                // Arrange
+                CommentOnPost comment1 = createCommentOnPost(UUID.randomUUID(), actor1Id, post, now.minusDays(1)); // Actor
+                                                                                                                   // 1
+                                                                                                                   // exists
+                                                                                                                   // in
+                                                                                                                   // auth
+                                                                                                                   // response
+                CommentOnPost comment2 = createCommentOnPost(UUID.randomUUID(), actor2Id, post, now.minusDays(2)); // Actor
+                                                                                                                   // 2
+                                                                                                                   // doesn't
+                                                                                                                   // exist
+                                                                                                                   // in
+                                                                                                                   // auth
+                                                                                                                   // response
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(List.of(comment1, comment2));
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+
+                // Mock Auth Service - only returns info for actor1Id
+                Map<UUID, PostedByData> userInfoMap = new HashMap<>();
+                userInfoMap.put(actor1Id, new PostedByData(actor1Id, "Actor One", "pic1.jpg"));
+                mockAuthServiceResponse(userInfoMap);
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert
+                assertEquals(2, notifications.size());
+                // Notification for comment1 (actor1) - Should have full info
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(0).getType());
+                assertEquals(actor1Id, notifications.get(0).getActorUserId());
+                assertEquals("Actor One", notifications.get(0).getActorName());
+                assertEquals("pic1.jpg", notifications.get(0).getActorProfilePictureUrl());
+                assertEquals("1 day ago", notifications.get(0).getTimeAgo());
+                // Notification for comment2 (actor2) - Should have default info
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(1).getType());
+                assertEquals(actor2Id, notifications.get(1).getActorUserId());
+                assertEquals("Unknown User", notifications.get(1).getActorName()); // Defaulted
+                assertNull(notifications.get(1).getActorProfilePictureUrl()); // Defaulted
+                assertEquals("2 days ago", notifications.get(1).getTimeAgo());
+
+                verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_AuthServiceReturnsEmptyMap() {
+                // Arrange
+                CommentOnPost commentOnUserPost = createCommentOnPost(UUID.randomUUID(), actor1Id, post,
+                                now.minusDays(1));
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(List.of(commentOnUserPost));
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+
+                // Mock Auth Service returning empty map
+                mockAuthServiceResponse(Collections.emptyMap());
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert: Notification created with default info
+                assertEquals(1, notifications.size());
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(0).getType());
+                assertEquals(actor1Id, notifications.get(0).getActorUserId());
+                assertEquals("Unknown User", notifications.get(0).getActorName());
+                assertNull(notifications.get(0).getActorProfilePictureUrl());
+                assertEquals("1 day ago", notifications.get(0).getTimeAgo());
+
+                verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class));
+        }
+
+        @Test
+        void getNotifications_TimeAgoCalculation() {
+                // Arrange
+                CommentOnPost commentToday = createCommentOnPost(UUID.randomUUID(), actor1Id, post, now.minusHours(1)); // Today
+                CommentOnPost commentYesterday = createCommentOnPost(UUID.randomUUID(), actor1Id, post,
+                                now.minusDays(1).minusHours(1)); // Yesterday
+                CommentOnPost commentTwoDaysAgo = createCommentOnPost(UUID.randomUUID(), actor1Id, post,
+                                now.minusDays(2).minusHours(1)); // 2 days ago
+                CommentOnPost commentThirtyDaysAgo = createCommentOnPost(UUID.randomUUID(), actor1Id, post,
+                                now.minusDays(30).minusHours(1)); // 30 days ago
+
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(List.of(commentToday, commentYesterday, commentTwoDaysAgo,
+                                                commentThirtyDaysAgo));
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+
+                Map<UUID, PostedByData> userInfoMap = new HashMap<>();
+                userInfoMap.put(actor1Id, new PostedByData(actor1Id, "Actor One", "pic1.jpg"));
+                mockAuthServiceResponse(userInfoMap);
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert
+                assertEquals(4, notifications.size());
+                // Sorted by date descending
+                assertEquals("Today", notifications.get(0).getTimeAgo());
+                assertEquals("1 day ago", notifications.get(1).getTimeAgo());
+                assertEquals("2 days ago", notifications.get(2).getTimeAgo());
+                assertEquals("30 days ago", notifications.get(3).getTimeAgo());
+        }
+
+        @Test
+        void getNotifications_SiblingReply_UserHasNoReplies_ShouldNotQuerySiblings() {
+                // Arrange
+                // User has *not* replied in the last 30 days
+                when(commentOnCommentRepository.findByPostedByAndCreatedAtGreaterThanEqual(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(Collections.emptyList());
+
+                // Setup other notification types to ensure they are still processed
+                CommentOnPost commentOnUserPost = createCommentOnPost(UUID.randomUUID(), actor1Id, post,
+                                now.minusDays(1));
+                when(commentOnPostRepository.findCommentsOnUserPostsSince(eq(testUserId), any(LocalDateTime.class)))
+                                .thenReturn(List.of(commentOnUserPost));
+                CommentOnComment replyToUserComment = createCommentOnComment(UUID.randomUUID(), actor2Id, parentComment,
+                                now.minusDays(2));
+                when(commentOnCommentRepository.findRepliesToUserCommentsSince(eq(testUserId),
+                                any(LocalDateTime.class)))
+                                .thenReturn(List.of(replyToUserComment));
+
+                // Mock Auth Service
+                Map<UUID, PostedByData> userInfoMap = new HashMap<>();
+                userInfoMap.put(actor1Id, new PostedByData(actor1Id, "Actor One", "pic1.jpg"));
+                userInfoMap.put(actor2Id, new PostedByData(actor2Id, "Actor Two", "pic2.jpg"));
+                mockAuthServiceResponse(userInfoMap);
+
+                // Act
+                List<NotificationDto> notifications = notificationService.getNotifications(testUserId);
+
+                // Assert
+                assertEquals(2, notifications.size()); // Only comment and reply notifications
+                assertEquals(NotificationType.NEW_COMMENT_ON_POST, notifications.get(0).getType());
+                assertEquals(NotificationType.NEW_REPLY_TO_COMMENT, notifications.get(1).getType());
+
+                // Crucially, verify findSiblingRepliesSince was *not* called
+                verify(commentOnCommentRepository, never()).findSiblingRepliesSince(any(), any(), any());
+                // Verify auth service was still called for the other actors
+                verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class),
+                                any(ParameterizedTypeReference.class));
+        }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,4 +10,5 @@ spring.h2.console.enabled=true
 # JWT
 jwt.secret=testsecretkey00wjii9rguinj3k4kiwedsiuonj32jiiew99ij324rjifsnf
 # Auth service endpoint for tests
+be-auth.base-url=http://localhost:8080
 be-auth=http://localhost:8080


### PR DESCRIPTION
This PR adds an in‑app comment notification feature that lets users see when someone:

1. Comments on their post (parent or child comment).

2. Replies to a parent comment they made.

3. Adds another reply (sibling comment) under a child comment they made.

All notification logic uses the existing comment models; no new database tables are introduced. We expose a single endpoint to fetch notifications from the last 30 days, returning the commenter’s ID, name, profile picture URL, comment type, target IDs, and a human‑readable "time ago".