### PR TITLE
Endpoint for fetching limit on characters & post per day

### DIFF
--- a/src/main/java/com/safetypin/post/controller/LimitController.java
+++ b/src/main/java/com/safetypin/post/controller/LimitController.java
@@ -35,13 +35,7 @@ public class LimitController {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             UserDetails userDetails = (UserDetails) authentication.getPrincipal();
 
-
-            // Return success response
-            PostResponse response = makeResponse(userDetails.getTitleCharacterLimit());
-
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(response);
+            return createSuccessResponse(userDetails.getTitleCharacterLimit());
         }, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/com/safetypin/post/controller/LimitController.java
+++ b/src/main/java/com/safetypin/post/controller/LimitController.java
@@ -1,0 +1,126 @@
+package com.safetypin.post.controller;
+
+import com.safetypin.post.dto.PostResponse;
+import com.safetypin.post.dto.UserDetails;
+import com.safetypin.post.exception.InvalidPostDataException;
+import com.safetypin.post.exception.PostNotFoundException;
+import com.safetypin.post.exception.UnauthorizedAccessException;
+import com.safetypin.post.repository.PostRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.function.Supplier;
+
+@Slf4j
+@RestController
+@AllArgsConstructor
+@RequestMapping("/posts/limit")
+public class LimitController {
+    // make endpoint for fetching limit character in post title, character in caption/description/comment, limit post per day, posted today
+    private final PostRepository postRepository;
+
+    @GetMapping("/title")
+    public ResponseEntity<PostResponse> getLimitTitle() {
+
+        return executeWithExceptionHandling(() -> {
+            // Get user details from security context
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+
+            // Return success response
+            PostResponse response = makeResponse(userDetails.getTitleCharacterLimit());
+
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(response);
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @GetMapping("/caption")
+    public ResponseEntity<PostResponse> getLimitCaption() {
+
+        return executeWithExceptionHandling(() -> {
+            // Get user details from security context
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+
+            return createSuccessResponse(userDetails.getCaptionCharacterLimit());
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @GetMapping("/post-per-day")
+    public ResponseEntity<PostResponse> getLimitPostPerDay() {
+
+        return executeWithExceptionHandling(() -> {
+            // Get user details from security context
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+            return createSuccessResponse(userDetails.getPostPerDayLimit());
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @GetMapping("/today-post-count")
+    public ResponseEntity<PostResponse> getTodayPostCount() {
+
+        return executeWithExceptionHandling(() -> {
+            // Get user details from security context
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+
+            return createSuccessResponse(postRepository.countPostsByUserToday(userDetails.getUserId()));
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private PostResponse makeResponse(Object data) {
+        return new PostResponse(
+                true,
+                "Request successfully processed",
+                data);
+    }
+
+    // Generic exception handler for controller methods
+    private ResponseEntity<PostResponse> executeWithExceptionHandling(
+            Supplier<ResponseEntity<PostResponse>> action,
+            HttpStatus errorStatus) {
+        try {
+            return action.get();
+        } catch (InvalidPostDataException e) {
+            return createErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+        } catch (PostNotFoundException e) {
+            return createErrorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (UnauthorizedAccessException e) {
+            return createErrorResponse(HttpStatus.FORBIDDEN, e.getMessage());
+        } catch (Exception e) {
+            log.error("Unexpected error occurred: {}", e.getMessage(), e);
+            return createErrorResponse(errorStatus, "Error processing request: " + e.getMessage());
+        }
+    }
+
+    // Helper method to create error responses
+    private ResponseEntity<PostResponse> createErrorResponse(HttpStatus status, String message) {
+        PostResponse errorResponse = new PostResponse(false, message, null);
+        return ResponseEntity.status(status)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(errorResponse);
+    }
+
+    // Helper method to create success responses
+    private ResponseEntity<PostResponse> createSuccessResponse(Object data) {
+        PostResponse response = new PostResponse(true, null, data);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(response);
+    }
+}

--- a/src/main/java/com/safetypin/post/controller/LimitController.java
+++ b/src/main/java/com/safetypin/post/controller/LimitController.java
@@ -77,13 +77,6 @@ public class LimitController {
         }, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    private PostResponse makeResponse(Object data) {
-        return new PostResponse(
-                true,
-                "Request successfully processed",
-                data);
-    }
-
     // Generic exception handler for controller methods
     private ResponseEntity<PostResponse> executeWithExceptionHandling(
             Supplier<ResponseEntity<PostResponse>> action,


### PR DESCRIPTION
This PR introduces a new REST controller, LimitController, which provides endpoints for retrieving various post-related limits for the authenticated user. These include:

- GET /posts/limit/title — Returns the character limit for post titles.
- GET /posts/limit/caption — Returns the character limit for captions.
- GET /posts/limit/post-per-day — Returns the daily post limit for the user.
- GET /posts/limit/today-post-count — Returns how many posts the user has created today.

Security:
All endpoints extract the authenticated UserDetails from the security context.
Only authenticated users can access these endpoints.